### PR TITLE
Fixed but where running with -p would lag until hitting enter again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@
 
 # Internal deps
 /build
+
+# Byproducts of running cmake and make
+CMakeCache.txt
+CMakeFiles/
+Makefile
+MazeSolver
+cmake_install.cmake
+config.h
+mazeDataFile.txt

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,9 @@ int main(int argc, char *argv[])
         if (string(argv[1]) == "-p"){
             doPrint = true;
             std::cout << "Console print enabled\n";
+        }else{
+            // ignore the line feed read in by CIN so our first loop doesn't read a \n and exit right away IF user didnt pass in -p flag
+            std::cin.ignore(256, '\n');
         }
     }else{
         // give the user another chance to enable console print
@@ -41,9 +44,9 @@ int main(int argc, char *argv[])
             std::cout << "Console print disabled\n";
         }else
             std::cout << "Unrecognized input... disabling console print\n";
+        // ignore the line feed read in by CIN so our first loop doesn't read a \n and exit right away IF user didnt pass in -p flag
+        std::cin.ignore(256, '\n');
     }
-    // ignore the line feed read in by CIN so our first loop doesn't read a \n and exit right away
-    std::cin.ignore(256, '\n');
     std::cout << "\n\n------------------------------------------------------------------\n";
 
     int rows, cols;


### PR DESCRIPTION
## Changes:

1. Added a few lines to the .gitignore file in order to not have files that result from running make and cmake get committed to the repo

2. When running the program with the -p flag before, it would hang, not letting the user input a maze size until they clicked enter (with no instruction). The line of code that resulted in that behavior was necessary however to prevent early termination without that flag. In this PR, the `std::cin.ignore(256, '\n');` that prevents early termination will only run when the user doesn't pass in the -p flag. 

Let me know what you think of these changes. I see absolutely no way that the behavior would be any different in a Windows environment, but if you run into issues with the Windows build with these changes let me know and I can fix it, and submit another PR.